### PR TITLE
Relax restrictive upper bound on hedgehog

### DIFF
--- a/ascii-predicates/ascii-predicates.cabal
+++ b/ascii-predicates/ascii-predicates.cabal
@@ -57,4 +57,4 @@ test-suite test-ascii-predicates
 
     build-depends:
       , ascii-predicates
-      , hedgehog ^>= 1.1.2 || ^>= 1.2
+      , hedgehog >= 1.1.2 && < 1.5


### PR DESCRIPTION
Hi there!

Looks like [ascii](hackage.haskell.org/package/ascii) will get broken on nixpkgs through this dependency, and ascii-numbers, after the latest hackage bump since hedgehog being tracked is now 1.4.